### PR TITLE
unify renderViewport() between Vulkan and OpenGL

### DIFF
--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -653,11 +653,7 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
-#ifdef NANOVG_VULKAN_IMPLEMENTATION
-	void (*renderViewport)(void* uptr, int width, int height, float devicePixelRatio);
-#else
     void (*renderViewport)(void* uptr, float width, float height, float devicePixelRatio);
-#endif
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGcompositeOperationState compositeOperation, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1376,10 +1376,10 @@ static int vknvg_renderGetTextureSize(void *uptr, int image, int *w, int *h) {
   }
   return 0;
 }
-static void vknvg_renderViewport(void *uptr, int width, int height, float devicePixelRatio) {
+static void vknvg_renderViewport(void *uptr, float width, float height, float devicePixelRatio) {
   VKNVGcontext *vk = (VKNVGcontext *)uptr;
-  vk->view[0] = (float)width;
-  vk->view[1] = (float)height;
+  vk->view[0] = width;
+  vk->view[1] = height;
 }
 static void vknvg_renderCancel(void *uptr) {
   VKNVGcontext *vk = (VKNVGcontext *)uptr;


### PR DESCRIPTION
Another proposal. I believe it fixes a couple of things:

The callback signature of `renderViewport()` was different between Vulkan and OpenGL. This was done via an `#ifdef`.

That has the following impacts:
- You have to `#define NANOVG_VULKAN_IMPLEMENTATION` when compiling `nanovg.c` for the Vulkan port or it will not work. This is different from the regular nanovg approach where you would just `#define NANOVG_VULKAN_IMPLEMENTATION` before `#include "nanovg_vk.h"`.
- That also means you have to decide for one implementation at compile time - `OpenGL` or `Vulkan`. Because if `#define NANOVG_VULKAN_IMPLEMENTATION` was set when compiling `nanovg.c` the OpenGL backend would not work.

I could not spot a reason why the Vulkan version of `renderViewport()` has a different signature. Especially because the changed values from `float` to `int` are cast back to `float` inside that function anyway.

With this change you can make use of both backends, OpenGL and Vulkan in the same application and eventually gracefully fall back to OpenGL when Vulkan feature is not available on the host machine.
