### PR TITLE
free potenital allocated memory

### DIFF
--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1664,6 +1664,11 @@ static void vknvg_renderDelete(void *uptr) {
   }
 
   free(vk->textures);
+  free(vk->pipelines);
+  free(vk->calls);
+  free(vk->paths);
+  free(vk->verts);
+  free(vk->uniforms);
   free(vk);
 }
 


### PR DESCRIPTION
I know you are not maintaining this repo.. (・・；)

But I'd still like to contribute when I find some things that may be helpful to others discovering this repository as well.

I found my valgrind telling me about `vk->verts` leaking. So I guessed all variables that are potentially being `realloc`-ed should be freed when destroying the instance.
