### PR TITLE
Optimizations > Cached Descriptor Sets, Implied Multiple Frames in Flight, Fencing for faster perf 2X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ Thumbs.db
 
 ## Build dir
 build/*
+cmake-build-debug/
 
 ## xcode specific
 *xcuserdata*
+
+## jetbrains specific
+.idea/

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -148,8 +148,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
   /* Queue the command buffer for execution */
-  vkResetFences(device, 1, &fb->flight_fence[fb->current_buffer]);
-  res = vkQueueSubmit(queue, 1, &submit_info, 0);
+  res = vkQueueSubmit(queue, 1, &submit_info, fb->flight_fence[fb->current_buffer]);
   assert(res == VK_SUCCESS);
 
   /* Now present the image in the window */
@@ -173,7 +172,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   assert(res == VK_SUCCESS);
 
   res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_buffer], true, UINT64_MAX);
-  assert(res == VK_SUCCESS || res == VK_TIMEOUT);
+  assert(res == VK_SUCCESS);
 
   fb->current_frame = (fb->current_frame + 1) % fb->swapchain_image_count;
 }

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -53,7 +53,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
 
   // Get the index of the next available swapchain image:
   res = vkAcquireNextImageKHR(device, fb->swap_chain, UINT64_MAX,
-                              fb->present_complete_semaphore[fb->current_buffer],
+                              fb->present_complete_semaphore[fb->current_frame],
                               VK_NULL_HANDLE,
                               &fb->current_buffer);
 
@@ -140,12 +140,12 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   VkSubmitInfo submit_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
   submit_info.pNext = NULL;
   submit_info.waitSemaphoreCount = 1;
-  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_buffer];
+  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_frame];
   submit_info.pWaitDstStageMask = &pipe_stage_flags;
   submit_info.commandBufferCount = 1;
   submit_info.pCommandBuffers = &cmd_buffer[fb->current_buffer];
   submit_info.signalSemaphoreCount = 1;
-  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
+  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
   /* Queue the command buffer for execution */
   vkResetFences(device, 1, &fb->flight_fence[fb->current_buffer]);
@@ -160,7 +160,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   present.pSwapchains = &fb->swap_chain;
   present.pImageIndices = &fb->current_buffer;
   present.waitSemaphoreCount = 1;
-  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
+  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
   res = vkQueuePresentKHR(queue, &present);
   if (res == VK_ERROR_OUT_OF_DATE_KHR)
@@ -175,7 +175,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_buffer], true, UINT64_MAX);
   assert(res == VK_SUCCESS || res == VK_TIMEOUT);
 
-  //fb->current_frame = (fb->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+  fb->current_frame = (fb->current_frame + 1) % fb->swapchain_image_count;
 }
 
 int main() {

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -48,7 +48,7 @@ static void key(GLFWwindow *window, int key, int scancode, int action, int mods)
     premult = !premult;
 }
 
-void prepareFrame(VkDevice device, VkCommandBuffer cmd_buffer, FrameBuffers *fb) {
+void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
   VkResult res;
 
   // Get the index of the next available swapchain image:
@@ -65,7 +65,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer cmd_buffer, FrameBuffers *fb)
   assert(res == VK_SUCCESS);
 
   const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  res = vkBeginCommandBuffer(cmd_buffer, &cmd_buf_info);
+  res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
   assert(res == VK_SUCCESS);
 
   VkClearValue clear_values[2];
@@ -88,7 +88,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer cmd_buffer, FrameBuffers *fb)
   rp_begin.clearValueCount = 2;
   rp_begin.pClearValues = clear_values;
 
-  vkCmdBeginRenderPass(cmd_buffer, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+  vkCmdBeginRenderPass(cmd_buffer[fb->current_buffer], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
 
   VkViewport viewport;
   viewport.width = (float) fb->buffer_size.width;
@@ -97,15 +97,15 @@ void prepareFrame(VkDevice device, VkCommandBuffer cmd_buffer, FrameBuffers *fb)
   viewport.maxDepth = (float) 1.0f;
   viewport.x = (float) rp_begin.renderArea.offset.x;
   viewport.y = (float) rp_begin.renderArea.offset.y;
-  vkCmdSetViewport(cmd_buffer, 0, 1, &viewport);
+  vkCmdSetViewport(cmd_buffer[fb->current_buffer], 0, 1, &viewport);
 
   VkRect2D scissor = rp_begin.renderArea;
-  vkCmdSetScissor(cmd_buffer, 0, 1, &scissor);
+  vkCmdSetScissor(cmd_buffer[fb->current_buffer], 0, 1, &scissor);
 }
-void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer cmd_buffer, FrameBuffers *fb) {
+void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
   VkResult res;
 
-  vkCmdEndRenderPass(cmd_buffer);
+  vkCmdEndRenderPass(cmd_buffer[fb->current_buffer]);
 
   VkImageMemoryBarrier image_barrier = {
       .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -124,7 +124,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer cmd_buffer, Fra
           .layerCount = 1,
       },
   };
-  vkCmdPipelineBarrier(cmd_buffer,
+  vkCmdPipelineBarrier(cmd_buffer[fb->current_buffer],
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
             0,
@@ -132,7 +132,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer cmd_buffer, Fra
             0, NULL,
             1, &image_barrier);
 
-  vkEndCommandBuffer(cmd_buffer);
+  vkEndCommandBuffer(cmd_buffer[fb->current_buffer]);
 
   VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
@@ -142,7 +142,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer cmd_buffer, Fra
   submit_info.pWaitSemaphores = &fb->present_complete_semaphore;
   submit_info.pWaitDstStageMask = &pipe_stage_flags;
   submit_info.commandBufferCount = 1;
-  submit_info.pCommandBuffers = &cmd_buffer;
+  submit_info.pCommandBuffers = cmd_buffer + fb->current_buffer;
   submit_info.signalSemaphoreCount = 1;
   submit_info.pSignalSemaphores = &fb->render_complete_semaphore;
 
@@ -284,12 +284,14 @@ int main() {
   vkGetDeviceQueue(device->device, device->graphicsQueueFamilyIndex, 0, &queue);
   FrameBuffers fb = createFrameBuffers(device, surface, queue, winWidth, winHeight, 0);
 
-  VkCommandBuffer cmd_buffer = createCmdBuffer(device->device, device->commandPool);
+  VkCommandBuffer *cmd_buffer = createCmdBuffer(device->device, device->commandPool, fb.swapchain_image_count);
   VKNVGCreateInfo create_info = {0};
   create_info.device = device->device;
   create_info.gpu = device->gpu;
   create_info.renderpass = fb.render_pass;
   create_info.cmdBuffer = cmd_buffer;
+  create_info.swapChainImageCount = fb.swapchain_image_count;
+  create_info.currentBuffer = &fb.current_buffer;
 
   int flags = 0;
 #ifndef NDEBUG
@@ -361,6 +363,8 @@ int main() {
   vkDestroyInstance(instance, NULL);
 
   glfwDestroyWindow(window);
+
+  free(cmd_buffer);
 
   printf("Average Frame Time: %.2f ms\n", getGraphAverage(&fps) * 1000.0f);
   //printf("          CPU Time: %.2f ms\n", getGraphAverage(&cpuGraph) * 1000.0f);

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -66,7 +66,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   assert(res == VK_SUCCESS);
 
   const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
+  res = vkBeginCommandBuffer(cmd_buffer[fb->current_frame], &cmd_buf_info);
   assert(res == VK_SUCCESS);
 
   VkClearValue clear_values[2];

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -18,9 +18,6 @@
 #ifndef DEMO_VULKAN_VALIDATON_LAYER
 #   define DEMO_VULKAN_VALIDATON_LAYER 0
 #endif
-#ifndef MAX_FRAMES_IN_FLIGHT
-#   define MAX_FRAMES_IN_FLIGHT 6
-#endif
 
 #include "nanovg.h"
 #include "nanovg_vk.h"
@@ -56,11 +53,9 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
 
   // Get the index of the next available swapchain image:
   res = vkAcquireNextImageKHR(device, fb->swap_chain, UINT64_MAX,
-                              fb->present_complete_semaphore,
-                              0,
+                              fb->present_complete_semaphore[fb->current_frame],
+                              VK_NULL_HANDLE,
                               &fb->current_buffer);
-  //TODO delete this
-  fb->current_frame = fb->current_buffer;
 
   if (res == VK_ERROR_OUT_OF_DATE_KHR)
   {
@@ -145,14 +140,15 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   VkSubmitInfo submit_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
   submit_info.pNext = NULL;
   submit_info.waitSemaphoreCount = 1;
-  submit_info.pWaitSemaphores = &fb->present_complete_semaphore;
+  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_frame];
   submit_info.pWaitDstStageMask = &pipe_stage_flags;
   submit_info.commandBufferCount = 1;
-  submit_info.pCommandBuffers = cmd_buffer + fb->current_frame;
+  submit_info.pCommandBuffers = &cmd_buffer[fb->current_frame];
   submit_info.signalSemaphoreCount = 1;
-  submit_info.pSignalSemaphores = &fb->render_complete_semaphore;
+  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
   /* Queue the command buffer for execution */
+  vkResetFences(device, 1, &fb->flight_fence[fb->current_frame]);
   res = vkQueueSubmit(queue, 1, &submit_info, 0);
   assert(res == VK_SUCCESS);
 
@@ -164,7 +160,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   present.pSwapchains = &fb->swap_chain;
   present.pImageIndices = &fb->current_buffer;
   present.waitSemaphoreCount = 1;
-  present.pWaitSemaphores = &fb->render_complete_semaphore;
+  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
   res = vkQueuePresentKHR(queue, &present);
   if (res == VK_ERROR_OUT_OF_DATE_KHR)
@@ -176,7 +172,10 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   }
   assert(res == VK_SUCCESS);
 
-  res = vkQueueWaitIdle(queue);
+  res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_frame], true, UINT64_MAX);
+  assert(res == VK_SUCCESS || res == VK_TIMEOUT);
+
+  fb->current_frame = (fb->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
 }
 
 int main() {

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -360,6 +360,9 @@ int main() {
     glfwPollEvents();
   }
 
+  res = vkQueueWaitIdle(queue);
+  assert(res == VK_SUCCESS);
+
   freeDemoData(vg, &data);
   nvgDeleteVk(vg);
 

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -302,7 +302,7 @@ void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidt
     create_info.renderpass = fb->render_pass;
     create_info.cmdBuffer = (*cmd_buffer);
     create_info.swapchainImageCount = fb->swapchain_image_count;
-    create_info.currentFrame = &fb->current_buffer;
+    create_info.currentFrame = &fb->current_frame;
 
     int flags = 0;
 #ifndef NDEBUG
@@ -766,7 +766,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
                 resize_event=false;
             }else{
                 if (!os_window.is_minimized){
-                    prepareFrame(device->device, cmd_buffer[fb->current_buffer], &fb);
+                    prepareFrame(device->device, cmd_buffer[fb.current_frame], &fb);
                     if(resize_event)break;
                 }
                 updateGraph(&fps, os_window.app_data.iTimeDelta);
@@ -786,7 +786,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
                     sleep_ms(10);
                 }
                 else {
-                    submitFrame(device->device, queue, cmd_buffer, &fb);
+                    submitFrame(device->device, queue, cmd_buffer[fb.current_frame], &fb);
                 }
                 update_params(&os_window.app_data, os_window.fps_lock);
             }

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -382,6 +382,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine,
         RedrawWindow(os_window.window, NULL, NULL, RDW_INTERNALPAINT);
     }
 
+    res = vkQueueWaitIdle(queue);
+    assert(res == VK_SUCCESS);
+
     freeDemoData(vg, &data);
     nvgDeleteVk(vg);
     destroyFrameBuffers(device, &fb, queue);

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -302,7 +302,7 @@ void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidt
     create_info.renderpass = fb->render_pass;
     create_info.cmdBuffer = (*cmd_buffer);
     create_info.swapchainImageCount = fb->swapchain_image_count;
-    create_info.currentBuffer = &fb->current_buffer;
+    create_info.currentFrame = &fb->current_buffer;
 
     int flags = 0;
 #ifndef NDEBUG

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -447,11 +447,11 @@ int main(int argc, char **argv)
   VkQueue queue;
   NVGcontext *vg;
   FrameBuffers fb;
-  VkCommandBuffer cmd_buffer;
+  VkCommandBuffer* cmd_buffer;
   DemoData data;
   PerfGraph fps;
   init_nanovg_vulkan(gpu, &surface, winWidth, winHeight, &queue, &vg, &fb, &cmd_buffer, &device, &fps, &data);
-  
+
     while (!os_window.app_data.quit)
     {
         xcb_generic_event_t *event;
@@ -477,7 +477,7 @@ int main(int argc, char **argv)
         if ((resize_event)||(winWidth != cwinWidth || winHeight != cwinHeight)) {
           winWidth = cwinWidth;
           winHeight = cwinHeight;
-          destroyFrameBuffers(device, &fb);
+          destroyFrameBuffers(device, &fb, queue);
           fb = createFrameBuffers(device, surface, queue, winWidth, winHeight, 0);
           resize_event=false;
         }else{

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -483,7 +483,7 @@ int main(int argc, char **argv)
         }else{
           
           if (!os_window.is_minimized){
-            prepareFrame(device->device, cmd_buffer[fb->current_frame], &fb);
+            prepareFrame(device->device, cmd_buffer[fb.current_frame], &fb);
             if(resize_event)continue;
           }
           updateGraph(&fps, os_window.app_data.iTimeDelta);
@@ -503,7 +503,7 @@ int main(int argc, char **argv)
               sleep_ms(10);
           }
           else {
-            submitFrame(device->device, queue, cmd_buffer[fb->current_frame], &fb);
+            submitFrame(device->device, queue, cmd_buffer[fb.current_frame], &fb);
           }
           update_params(&os_window.app_data, os_window.fps_lock);
         }

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -32,6 +32,9 @@
 #ifndef DEMO_VULKAN_VALIDATON_LAYER
 #   define DEMO_VULKAN_VALIDATON_LAYER 0
 #endif
+#ifndef MAX_FRAMES_IN_FLIGHT
+#   define MAX_FRAMES_IN_FLIGHT 6
+#endif
 
 #include "nanovg.h"
 #include "nanovg_vk.h"
@@ -177,7 +180,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   assert(res == VK_SUCCESS);
 
   const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
+  res = vkBeginCommandBuffer(cmd_buffer[fb->current_frame], &cmd_buf_info);
   assert(res == VK_SUCCESS);
 
   VkClearValue clear_values[2];
@@ -200,7 +203,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   rp_begin.clearValueCount = 2;
   rp_begin.pClearValues = clear_values;
 
-  vkCmdBeginRenderPass(cmd_buffer[fb->current_buffer], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+  vkCmdBeginRenderPass(cmd_buffer[fb->current_frame], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
 
   VkViewport viewport;
   viewport.width = (float) fb->buffer_size.width;
@@ -209,16 +212,16 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   viewport.maxDepth = (float) 1.0f;
   viewport.x = (float) rp_begin.renderArea.offset.x;
   viewport.y = (float) rp_begin.renderArea.offset.y;
-  vkCmdSetViewport(cmd_buffer[fb->current_buffer], 0, 1, &viewport);
+  vkCmdSetViewport(cmd_buffer[fb->current_frame], 0, 1, &viewport);
 
   VkRect2D scissor = rp_begin.renderArea;
-  vkCmdSetScissor(cmd_buffer[fb->current_buffer], 0, 1, &scissor);
+  vkCmdSetScissor(cmd_buffer[fb->current_frame], 0, 1, &scissor);
 }
 
 void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
   VkResult res;
 
-  vkCmdEndRenderPass(cmd_buffer[fb->current_buffer]);
+  vkCmdEndRenderPass(cmd_buffer[fb->current_frame]);
 
   VkImageMemoryBarrier image_barrier = {
       .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -237,7 +240,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
           .layerCount = 1,
       },
   };
-  vkCmdPipelineBarrier(cmd_buffer[fb->current_buffer],
+  vkCmdPipelineBarrier(cmd_buffer[fb->current_frame],
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
             0,
@@ -245,7 +248,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
             0, NULL,
             1, &image_barrier);
 
-  vkEndCommandBuffer(cmd_buffer[fb->current_buffer]);
+  vkEndCommandBuffer(cmd_buffer[fb->current_frame]);
 
   VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
@@ -255,7 +258,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   submit_info.pWaitSemaphores = &fb->present_complete_semaphore;
   submit_info.pWaitDstStageMask = &pipe_stage_flags;
   submit_info.commandBufferCount = 1;
-  submit_info.pCommandBuffers = cmd_buffer + fb->current_buffer;
+  submit_info.pCommandBuffers = cmd_buffer + fb->current_frame;
   submit_info.signalSemaphoreCount = 1;
   submit_info.pSignalSemaphores = &fb->render_complete_semaphore;
 
@@ -293,14 +296,14 @@ void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidt
   vkGetDeviceQueue((*device)->device, (*device)->graphicsQueueFamilyIndex, 0, queue);
   *fb = createFrameBuffers((*device), *surface, *queue, winWidth, winHeight, 0);
 
-  (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, fb->swapchain_image_count);
+  (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, MAX_FRAMES_IN_FLIGHT);
   VKNVGCreateInfo create_info = {0};
   create_info.device = (*device)->device;
   create_info.gpu = (*device)->gpu;
   create_info.renderpass = fb->render_pass;
   create_info.cmdBuffer = (*cmd_buffer);
-  create_info.swapChainImageCount = fb->swapchain_image_count;
-  create_info.currentBuffer = &fb->current_buffer;
+  create_info.maxFramesInFlight = MAX_FRAMES_IN_FLIGHT;
+  create_info.currentFrame = &fb->current_frame;
 
   int flags = 0;
 #ifndef NDEBUG

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -63,7 +63,7 @@ struct app_data_struct{
     float iTime; //time
     float iTimeDelta; //time delta
     int iFrame; //frames
-    
+
     bool pause; //pause clicked
     bool quit; //quit clicked/happend
     bool blowup; // nanovg demo test (space hotkey)
@@ -84,20 +84,20 @@ struct app_os_window {
 #endif
     char name[APP_NAME_STR_LEN];
     bool fps_lock; //key pressed event
-    
+
     bool is_minimized; //window controled events
-    
+
     struct app_data_struct app_data;
 };
 
 struct my_time_struct{
-  int msec;
-  int sec;
-  int min;
-  int hour;
-  int day;
-  int month;
-  int year; 
+    int msec;
+    int sec;
+    int min;
+    int hour;
+    int day;
+    int month;
+    int year;
 };
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -161,168 +161,166 @@ void init_win_params(struct app_os_window *os_window)
 bool resize_event = false;
 
 void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
-  VkResult res;
+    VkResult res;
 
-  // Get the index of the next available swapchain image:
-  res = vkAcquireNextImageKHR(device, fb->swap_chain, UINT64_MAX,
-                              fb->present_complete_semaphore[fb->current_buffer],
-                              VK_NULL_HANDLE,
-                              &fb->current_buffer);
-  if (res == VK_ERROR_OUT_OF_DATE_KHR)
-  {
-      resize_event = true;
-      res = 0;
-      return;
-  }
-  assert(res == VK_SUCCESS);
+    // Get the index of the next available swapchain image:
+    res = vkAcquireNextImageKHR(device, fb->swap_chain, UINT64_MAX,
+                                fb->present_complete_semaphore[fb->current_frame],
+                                VK_NULL_HANDLE,
+                                &fb->current_buffer);
+    if (res == VK_ERROR_OUT_OF_DATE_KHR)
+    {
+        resize_event = true;
+        res = 0;
+        return;
+    }
+    assert(res == VK_SUCCESS);
 
-  const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
-  assert(res == VK_SUCCESS);
+    const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
+    assert(res == VK_SUCCESS);
 
-  VkClearValue clear_values[2];
-  clear_values[0].color.float32[0] = 0.3f;
-  clear_values[0].color.float32[1] = 0.3f;
-  clear_values[0].color.float32[2] = 0.32f;
-  clear_values[0].color.float32[3] = 1.0f;
-  clear_values[1].depthStencil.depth = 1.0f;
-  clear_values[1].depthStencil.stencil = 0;
+    VkClearValue clear_values[2];
+    clear_values[0].color.float32[0] = 0.3f;
+    clear_values[0].color.float32[1] = 0.3f;
+    clear_values[0].color.float32[2] = 0.32f;
+    clear_values[0].color.float32[3] = 1.0f;
+    clear_values[1].depthStencil.depth = 1.0f;
+    clear_values[1].depthStencil.stencil = 0;
 
-  VkRenderPassBeginInfo rp_begin;
-  rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-  rp_begin.pNext = NULL;
-  rp_begin.renderPass = fb->render_pass;
-  rp_begin.framebuffer = fb->framebuffers[fb->current_buffer];
-  rp_begin.renderArea.offset.x = 0;
-  rp_begin.renderArea.offset.y = 0;
-  rp_begin.renderArea.extent.width = fb->buffer_size.width;
-  rp_begin.renderArea.extent.height = fb->buffer_size.height;
-  rp_begin.clearValueCount = 2;
-  rp_begin.pClearValues = clear_values;
+    VkRenderPassBeginInfo rp_begin;
+    rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    rp_begin.pNext = NULL;
+    rp_begin.renderPass = fb->render_pass;
+    rp_begin.framebuffer = fb->framebuffers[fb->current_buffer];
+    rp_begin.renderArea.offset.x = 0;
+    rp_begin.renderArea.offset.y = 0;
+    rp_begin.renderArea.extent.width = fb->buffer_size.width;
+    rp_begin.renderArea.extent.height = fb->buffer_size.height;
+    rp_begin.clearValueCount = 2;
+    rp_begin.pClearValues = clear_values;
 
-  vkCmdBeginRenderPass(cmd_buffer[fb->current_buffer], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdBeginRenderPass(cmd_buffer[fb->current_buffer], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
 
-  VkViewport viewport;
-  viewport.width = (float) fb->buffer_size.width;
-  viewport.height = (float) fb->buffer_size.height;
-  viewport.minDepth = (float) 0.0f;
-  viewport.maxDepth = (float) 1.0f;
-  viewport.x = (float) rp_begin.renderArea.offset.x;
-  viewport.y = (float) rp_begin.renderArea.offset.y;
-  vkCmdSetViewport(cmd_buffer[fb->current_buffer], 0, 1, &viewport);
+    VkViewport viewport;
+    viewport.width = (float) fb->buffer_size.width;
+    viewport.height = (float) fb->buffer_size.height;
+    viewport.minDepth = (float) 0.0f;
+    viewport.maxDepth = (float) 1.0f;
+    viewport.x = (float) rp_begin.renderArea.offset.x;
+    viewport.y = (float) rp_begin.renderArea.offset.y;
+    vkCmdSetViewport(cmd_buffer[fb->current_buffer], 0, 1, &viewport);
 
-  VkRect2D scissor = rp_begin.renderArea;
-  vkCmdSetScissor(cmd_buffer[fb->current_buffer], 0, 1, &scissor);
+    VkRect2D scissor = rp_begin.renderArea;
+    vkCmdSetScissor(cmd_buffer[fb->current_buffer], 0, 1, &scissor);
 }
 
 void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
-  VkResult res;
+    VkResult res;
 
-  vkCmdEndRenderPass(cmd_buffer[fb->current_buffer]);
+    vkCmdEndRenderPass(cmd_buffer[fb->current_buffer]);
 
-  VkImageMemoryBarrier image_barrier = {
-      .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-      .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-      .dstAccessMask = 0,
-      .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-      .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-      .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-      .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-      .image = fb->swap_chain_buffers[fb->current_buffer].image,
-      .subresourceRange = {
-          .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-          .baseMipLevel = 0,
-          .levelCount = 1,
-          .baseArrayLayer = 0,
-          .layerCount = 1,
-      },
-  };
-  vkCmdPipelineBarrier(cmd_buffer[fb->current_buffer],
-            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-            0,
-            0, NULL,
-            0, NULL,
-            1, &image_barrier);
+    VkImageMemoryBarrier image_barrier = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+            .dstAccessMask = 0,
+            .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = fb->swap_chain_buffers[fb->current_buffer].image,
+            .subresourceRange = {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .baseMipLevel = 0,
+                    .levelCount = 1,
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+            },
+    };
+    vkCmdPipelineBarrier(cmd_buffer[fb->current_buffer],
+                         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                         0,
+                         0, NULL,
+                         0, NULL,
+                         1, &image_barrier);
 
-  vkEndCommandBuffer(cmd_buffer[fb->current_buffer]);
+    vkEndCommandBuffer(cmd_buffer[fb->current_buffer]);
 
-  VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-  VkSubmitInfo submit_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
-  submit_info.pNext = NULL;
-  submit_info.waitSemaphoreCount = 1;
-  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_buffer];
-  submit_info.pWaitDstStageMask = &pipe_stage_flags;
-  submit_info.commandBufferCount = 1;
-  submit_info.pCommandBuffers = &cmd_buffer[fb->current_buffer];
-  submit_info.signalSemaphoreCount = 1;
-  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
+    VkSubmitInfo submit_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    submit_info.pNext = NULL;
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_frame];
+    submit_info.pWaitDstStageMask = &pipe_stage_flags;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &cmd_buffer[fb->current_buffer];
+    submit_info.signalSemaphoreCount = 1;
+    submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
-  /* Queue the command buffer for execution */
-  vkResetFences(device, 1, &fb->flight_fence[fb->current_buffer]);
-  res = vkQueueSubmit(queue, 1, &submit_info, 0);
-  assert(res == VK_SUCCESS);
+    /* Queue the command buffer for execution */
+    res = vkQueueSubmit(queue, 1, &submit_info, 0);
+    assert(res == VK_SUCCESS);
 
-  /* Now present the image in the window */
+    /* Now present the image in the window */
 
-  VkPresentInfoKHR present = {VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
-  present.pNext = NULL;
-  present.swapchainCount = 1;
-  present.pSwapchains = &fb->swap_chain;
-  present.pImageIndices = &fb->current_buffer;
-  present.waitSemaphoreCount = 1;
-  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
+    VkPresentInfoKHR present = {VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
+    present.pNext = NULL;
+    present.swapchainCount = 1;
+    present.pSwapchains = &fb->swap_chain;
+    present.pImageIndices = &fb->current_buffer;
+    present.waitSemaphoreCount = 1;
+    present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_frame];
 
-  res = vkQueuePresentKHR(queue, &present);
-  if (res == VK_ERROR_OUT_OF_DATE_KHR)
-  {
-      res = vkQueueWaitIdle(queue);
-      resize_event = true;
-      res = 0;
-      return;
-  }
-  assert(res == VK_SUCCESS);
+    fb->current_frame = fb->current_buffer;
 
-  res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_buffer], true, UINT64_MAX);
-  assert(res == VK_SUCCESS || res == VK_TIMEOUT);
+    res = vkQueuePresentKHR(queue, &present);
+    if (res == VK_ERROR_OUT_OF_DATE_KHR)
+    {
+        res = vkQueueWaitIdle(queue);
+        resize_event = true;
+        res = 0;
+        return;
+    }
+    assert(res == VK_SUCCESS);
 
-  //fb->current_frame = (fb->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+    res = vkQueueWaitIdle(queue);
 }
 
 void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidth, int winHeight, VkQueue *queue, NVGcontext **vg,
                         FrameBuffers *fb, VkCommandBuffer **cmd_buffer, VulkanDevice **device, PerfGraph *fps, DemoData *data){
-  *device = createVulkanDevice(gpu);
+    *device = createVulkanDevice(gpu);
 
-  vkGetDeviceQueue((*device)->device, (*device)->graphicsQueueFamilyIndex, 0, queue);
-  *fb = createFrameBuffers((*device), *surface, *queue, winWidth, winHeight, 0);
+    vkGetDeviceQueue((*device)->device, (*device)->graphicsQueueFamilyIndex, 0, queue);
+    *fb = createFrameBuffers((*device), *surface, *queue, winWidth, winHeight, 0);
 
-  (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, fb->swapchain_image_count);
-  VKNVGCreateInfo create_info = {0};
-  create_info.device = (*device)->device;
-  create_info.gpu = (*device)->gpu;
-  create_info.renderpass = fb->render_pass;
-  create_info.cmdBuffer = (*cmd_buffer);
-  create_info.swapchainImageCount = fb->swapchain_image_count;
-  create_info.currentBuffer = &fb->current_buffer;
+    (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, fb->swapchain_image_count);
+    VKNVGCreateInfo create_info = {0};
+    create_info.device = (*device)->device;
+    create_info.gpu = (*device)->gpu;
+    create_info.renderpass = fb->render_pass;
+    create_info.cmdBuffer = (*cmd_buffer);
+    create_info.swapchainImageCount = fb->swapchain_image_count;
+    create_info.currentBuffer = &fb->current_buffer;
 
-  int flags = 0;
+    int flags = 0;
 #ifndef NDEBUG
-  flags |= NVG_DEBUG; // unused in nanovg_vk
+    flags |= NVG_DEBUG; // unused in nanovg_vk
 #endif
 #if DEMO_ANTIALIAS
-  flags |= NVG_ANTIALIAS;
+    flags |= NVG_ANTIALIAS;
 #endif
 #if DEMO_STENCIL_STROKES
-  flags |= NVG_STENCIL_STROKES;
+    flags |= NVG_STENCIL_STROKES;
 #endif
 
-  *vg = nvgCreateVk(create_info, flags, *queue);
-  
-  if (loadDemoData(*vg, data) == -1)
-      exit(-1);
+    *vg = nvgCreateVk(create_info, flags, *queue);
 
-  initGraph(fps, GRAPH_RENDER_FPS, "Frame Time");
+    if (loadDemoData(*vg, data) == -1)
+        exit(-1);
+
+    initGraph(fps, GRAPH_RENDER_FPS, "Frame Time");
 }
 
 // -----end of nanovg Vulkan related functions
@@ -346,36 +344,36 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine,
 {
     MSG msg;
     bool done;
-    
+
     VkResult res;
     int retval = EXIT_FAILURE;
     init_win_params(&os_window);
 
     os_window.connection = hInstance;
-    
+
     const char *extension_names[] = {
-      VK_KHR_SURFACE_EXTENSION_NAME,
-      VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+            VK_KHR_SURFACE_EXTENSION_NAME,
+            VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
     };
     res = vk_init_ext(&instance, extension_names, sizeof extension_names / sizeof *extension_names);
-    
+
     app_create_window(&os_window);
     res = vk_create_surface(instance, &surface, &os_window);
     if (VK_SUCCESS != res)
     {
         printf("CreateSurface failed\n");
-        
+
         vkDestroyInstance(instance, NULL);
-        
+
         return retval;
     }
-    
+
     VkPhysicalDevice gpu = init_vk_gpu(instance, &surface);
-    
+
     int winWidth = os_window.app_data.iResolution[0];
     int winHeight = os_window.app_data.iResolution[1];
     init_nanovg_vulkan(gpu, &surface, winWidth, winHeight, &queue, &vg, &fb, &cmd_buffer, &device, &fps, &data);
-    
+
     done = false;
     while (!done)
     {
@@ -383,14 +381,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine,
         process_msg(&msg, &done);
         RedrawWindow(os_window.window, NULL, NULL, RDW_INTERNALPAINT);
     }
-    
+
     freeDemoData(vg, &data);
     nvgDeleteVk(vg);
     destroyFrameBuffers(device, &fb);
     vkDestroySurfaceKHR(instance, surface, NULL);
     destroyVulkanDevice(device);
-    
-    
+
+
     vkDestroyInstance(instance, NULL);
     free(cmd_buffer);
 
@@ -549,20 +547,20 @@ void update_params(struct app_data_struct *app_data, bool fps_lock)
 VkResult vk_init_ext(VkInstance *vk, const char *ext_names[], uint32_t ext_count)
 {
     VkApplicationInfo app_info = {
-        .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
-        .pApplicationName = "Nanovg demo",
-        .applicationVersion = 0x010000,
-        .pEngineName = "Nanovg demo",
-        .engineVersion = 0x010000,
-        .apiVersion = VK_API_VERSION_1_0,
+            .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+            .pApplicationName = "Nanovg demo",
+            .applicationVersion = 0x010000,
+            .pEngineName = "Nanovg demo",
+            .engineVersion = 0x010000,
+            .apiVersion = VK_API_VERSION_1_0,
     };
     VkInstanceCreateInfo info;
 
     info = (VkInstanceCreateInfo){
-        .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-        .pApplicationInfo = &app_info,
-        .enabledExtensionCount = ext_count,
-        .ppEnabledExtensionNames = ext_names,
+            .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+            .pApplicationInfo = &app_info,
+            .enabledExtensionCount = ext_count,
+            .ppEnabledExtensionNames = ext_names,
     };
 
     return vkCreateInstance(&info, NULL, vk);
@@ -595,279 +593,279 @@ VkResult vk_create_surface(VkInstance vk, VkSurfaceKHR *surface, struct app_os_w
 // selecting Vulkan GPu with priority to Diiscrete GPU, gpu[idx] is selected gpu
 // to select by hands set idx value(0/1/2/etc) by hands
 VkPhysicalDevice init_vk_gpu(VkInstance instance, VkSurfaceKHR *surface){
-  VkResult res;
-  uint32_t gpu_count = 0;
+    VkResult res;
+    uint32_t gpu_count = 0;
 
-  res = vkEnumeratePhysicalDevices(instance, &gpu_count, NULL);
-  if (VK_SUCCESS != res && res != VK_INCOMPLETE) {
-    printf("vkEnumeratePhysicalDevices failed %d \n", res);
-    exit(-1);
-  }
-  if (gpu_count < 1){
-    printf("No Vulkan device found.\n");
-    exit(-1);
-  }
-
-  VkPhysicalDevice gpu[32];
-  res = vkEnumeratePhysicalDevices(instance, &gpu_count, gpu);
-  if (res != VK_SUCCESS && res != VK_INCOMPLETE) {
-    printf("vkEnumeratePhysicalDevices failed %d \n", res);
-    exit(-1);
-  }
-
-  uint32_t idx = 0;
-  bool use_idx = false;
-  bool discrete_idx = false;
-  for (uint32_t i = 0; i < gpu_count && (!discrete_idx); i++)
-  {
-    uint32_t qfc = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(gpu[i], &qfc, NULL);
-    if (qfc < 1)continue;
-
-    VkQueueFamilyProperties *queue_family_properties;
-    queue_family_properties = malloc(qfc * sizeof(VkQueueFamilyProperties));
-
-    vkGetPhysicalDeviceQueueFamilyProperties(gpu[i], &qfc, queue_family_properties);
-
-    for (uint32_t j = 0; j < qfc; j++)
-    {
-      VkBool32 supports_present;
-      vkGetPhysicalDeviceSurfaceSupportKHR(gpu[i], j, *surface, &supports_present);
-
-      if ((queue_family_properties[j].queueFlags & VK_QUEUE_GRAPHICS_BIT) && supports_present)
-      {
-        
-        VkPhysicalDeviceProperties pr;
-        vkGetPhysicalDeviceProperties(gpu[i], &pr);
-        idx = i;
-        use_idx = true;
-        if(pr.deviceType==VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU){
-          discrete_idx = true;
-        }
-        break;
-      }
+    res = vkEnumeratePhysicalDevices(instance, &gpu_count, NULL);
+    if (VK_SUCCESS != res && res != VK_INCOMPLETE) {
+        printf("vkEnumeratePhysicalDevices failed %d \n", res);
+        exit(-1);
     }
-    free(queue_family_properties);
-  }
-  if (!use_idx){
-      printf("Not found suitable queue which supports graphics.\n");
-      exit(-1);
-  }
+    if (gpu_count < 1){
+        printf("No Vulkan device found.\n");
+        exit(-1);
+    }
 
-  printf("Using GPU device %lu\n", (unsigned long) idx);
-  return gpu[idx];
+    VkPhysicalDevice gpu[32];
+    res = vkEnumeratePhysicalDevices(instance, &gpu_count, gpu);
+    if (res != VK_SUCCESS && res != VK_INCOMPLETE) {
+        printf("vkEnumeratePhysicalDevices failed %d \n", res);
+        exit(-1);
+    }
+
+    uint32_t idx = 0;
+    bool use_idx = false;
+    bool discrete_idx = false;
+    for (uint32_t i = 0; i < gpu_count && (!discrete_idx); i++)
+    {
+        uint32_t qfc = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(gpu[i], &qfc, NULL);
+        if (qfc < 1)continue;
+
+        VkQueueFamilyProperties *queue_family_properties;
+        queue_family_properties = malloc(qfc * sizeof(VkQueueFamilyProperties));
+
+        vkGetPhysicalDeviceQueueFamilyProperties(gpu[i], &qfc, queue_family_properties);
+
+        for (uint32_t j = 0; j < qfc; j++)
+        {
+            VkBool32 supports_present;
+            vkGetPhysicalDeviceSurfaceSupportKHR(gpu[i], j, *surface, &supports_present);
+
+            if ((queue_family_properties[j].queueFlags & VK_QUEUE_GRAPHICS_BIT) && supports_present)
+            {
+
+                VkPhysicalDeviceProperties pr;
+                vkGetPhysicalDeviceProperties(gpu[i], &pr);
+                idx = i;
+                use_idx = true;
+                if(pr.deviceType==VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU){
+                    discrete_idx = true;
+                }
+                break;
+            }
+        }
+        free(queue_family_properties);
+    }
+    if (!use_idx){
+        printf("Not found suitable queue which supports graphics.\n");
+        exit(-1);
+    }
+
+    printf("Using GPU device %lu\n", (unsigned long) idx);
+    return gpu[idx];
 }
 
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 
 void process_msg(MSG *msg, bool *done){
-  static bool mouse_click[2]={false, false}; //click once control
-  if (msg->message == WM_QUIT)
-  {
-    *done = true;
-  }
-  else {
-    TranslateMessage(msg);
-    DispatchMessage(msg);
-  }
-  if (msg->message == WM_KEYDOWN) {
-    switch (msg->wParam)
+    static bool mouse_click[2]={false, false}; //click once control
+    if (msg->message == WM_QUIT)
     {
-    case VK_SPACE:
-      //os_window.app_data.pause = !os_window.app_data.pause;
-      os_window.app_data.blowup = !os_window.app_data.blowup;
-      break;
-    case 0x31: // 1
-      break;
-    case 0x32: // 2
-      os_window.fps_lock = !os_window.fps_lock;
-      break;
-    default: break;
+        *done = true;
     }
-  }
-  
-  if (msg->message == WM_MOUSEMOVE) {
-    os_window.app_data.iMouse[0] = (int)LOWORD(msg->lParam);
-    os_window.app_data.iMouse[1] = os_window.app_data.iResolution[1] - (int)HIWORD(msg->lParam);
-    switch (msg->wParam)
-    {
-    case WM_LBUTTONDOWN:os_window.app_data.iMouse_click[0] = true; break;
-    case WM_MBUTTONDOWN:break;
-    case WM_RBUTTONDOWN:os_window.app_data.iMouse_click[1] = true; break;
+    else {
+        TranslateMessage(msg);
+        DispatchMessage(msg);
     }
-    switch (msg->wParam)
-    {
-    case WM_LBUTTONUP:os_window.app_data.iMouse_click[0] = false; break;
-    case WM_MBUTTONUP:break;
-    case WM_RBUTTONUP:os_window.app_data.iMouse_click[1] = false; break;
+    if (msg->message == WM_KEYDOWN) {
+        switch (msg->wParam)
+        {
+            case VK_SPACE:
+                //os_window.app_data.pause = !os_window.app_data.pause;
+                os_window.app_data.blowup = !os_window.app_data.blowup;
+                break;
+            case 0x31: // 1
+                break;
+            case 0x32: // 2
+                os_window.fps_lock = !os_window.fps_lock;
+                break;
+            default: break;
+        }
     }
-  }
-  else {
 
-    switch (msg->message)
-    {
-    case WM_LBUTTONDOWN:os_window.app_data.iMouse_click[0] = true; break;
-    case WM_MBUTTONDOWN:break;
-    case WM_RBUTTONDOWN:os_window.app_data.iMouse_click[1] = true; break;
+    if (msg->message == WM_MOUSEMOVE) {
+        os_window.app_data.iMouse[0] = (int)LOWORD(msg->lParam);
+        os_window.app_data.iMouse[1] = os_window.app_data.iResolution[1] - (int)HIWORD(msg->lParam);
+        switch (msg->wParam)
+        {
+            case WM_LBUTTONDOWN:os_window.app_data.iMouse_click[0] = true; break;
+            case WM_MBUTTONDOWN:break;
+            case WM_RBUTTONDOWN:os_window.app_data.iMouse_click[1] = true; break;
+        }
+        switch (msg->wParam)
+        {
+            case WM_LBUTTONUP:os_window.app_data.iMouse_click[0] = false; break;
+            case WM_MBUTTONUP:break;
+            case WM_RBUTTONUP:os_window.app_data.iMouse_click[1] = false; break;
+        }
     }
-    switch (msg->message)
-    {
-    case WM_LBUTTONUP:os_window.app_data.iMouse_click[0] = false; break;
-    case WM_MBUTTONUP:break;
-    case WM_RBUTTONUP:os_window.app_data.iMouse_click[1] = false; break;
+    else {
+
+        switch (msg->message)
+        {
+            case WM_LBUTTONDOWN:os_window.app_data.iMouse_click[0] = true; break;
+            case WM_MBUTTONDOWN:break;
+            case WM_RBUTTONDOWN:os_window.app_data.iMouse_click[1] = true; break;
+        }
+        switch (msg->message)
+        {
+            case WM_LBUTTONUP:os_window.app_data.iMouse_click[0] = false; break;
+            case WM_MBUTTONUP:break;
+            case WM_RBUTTONUP:os_window.app_data.iMouse_click[1] = false; break;
+        }
     }
-  }
-  if(!os_window.app_data.iMouse_click[0]&&(!mouse_click[0])){
-    
-  }else{
-    if(os_window.app_data.iMouse_click[0]&&(!mouse_click[0])){
-      mouse_click[0]=true;
-      os_window.app_data.iMouse_lclick[0]=os_window.app_data.iMouse[0];
-      os_window.app_data.iMouse_lclick[1]=os_window.app_data.iMouse[1];
+    if(!os_window.app_data.iMouse_click[0]&&(!mouse_click[0])){
+
     }else{
-      if(!os_window.app_data.iMouse_click[0]&&(mouse_click[0])){
-        mouse_click[0]=false;
-        os_window.app_data.iMouse_lclick[0]=-abs(os_window.app_data.iMouse_lclick[0]);
-        os_window.app_data.iMouse_lclick[1]=-abs(os_window.app_data.iMouse_lclick[1]);
-      }
+        if(os_window.app_data.iMouse_click[0]&&(!mouse_click[0])){
+            mouse_click[0]=true;
+            os_window.app_data.iMouse_lclick[0]=os_window.app_data.iMouse[0];
+            os_window.app_data.iMouse_lclick[1]=os_window.app_data.iMouse[1];
+        }else{
+            if(!os_window.app_data.iMouse_click[0]&&(mouse_click[0])){
+                mouse_click[0]=false;
+                os_window.app_data.iMouse_lclick[0]=-abs(os_window.app_data.iMouse_lclick[0]);
+                os_window.app_data.iMouse_lclick[1]=-abs(os_window.app_data.iMouse_lclick[1]);
+            }
+        }
     }
-  }
-  if(!os_window.app_data.iMouse_click[1]&&(!mouse_click[1])){
-    
-  }else{
-    if(os_window.app_data.iMouse_click[1]&&(!mouse_click[1])){
-      mouse_click[1]=true;
-      os_window.app_data.iMouse_rclick[0]=os_window.app_data.iMouse[0];
-      os_window.app_data.iMouse_rclick[1]=os_window.app_data.iMouse[1];
+    if(!os_window.app_data.iMouse_click[1]&&(!mouse_click[1])){
+
     }else{
-      if(!os_window.app_data.iMouse_click[1]&&(mouse_click[1])){
-        mouse_click[1]=false;
-        os_window.app_data.iMouse_rclick[0]=-abs(os_window.app_data.iMouse_rclick[0]);
-        os_window.app_data.iMouse_rclick[1]=-abs(os_window.app_data.iMouse_rclick[1]);
-      }
+        if(os_window.app_data.iMouse_click[1]&&(!mouse_click[1])){
+            mouse_click[1]=true;
+            os_window.app_data.iMouse_rclick[0]=os_window.app_data.iMouse[0];
+            os_window.app_data.iMouse_rclick[1]=os_window.app_data.iMouse[1];
+        }else{
+            if(!os_window.app_data.iMouse_click[1]&&(mouse_click[1])){
+                mouse_click[1]=false;
+                os_window.app_data.iMouse_rclick[0]=-abs(os_window.app_data.iMouse_rclick[0]);
+                os_window.app_data.iMouse_rclick[1]=-abs(os_window.app_data.iMouse_rclick[1]);
+            }
+        }
     }
-  }
-  
+
 }
 
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-  switch (uMsg) {
-  case WM_CLOSE:
-    PostQuitMessage(0);
-    break;
-  case WM_PAINT:
-    
-    float pxRatio;
+    switch (uMsg) {
+        case WM_CLOSE:
+            PostQuitMessage(0);
+            break;
+        case WM_PAINT:
 
-    int winWidth = os_window.app_data.iResolution[0];
-    int winHeight = os_window.app_data.iResolution[1];
-    if (resize_event) {
-      destroyFrameBuffers(device, &fb);
-      fb = createFrameBuffers(device, surface, queue, winWidth, winHeight, 0);
-      resize_event=false;
-    }else{
-      if (!os_window.is_minimized){
-        prepareFrame(device->device, cmd_buffer, &fb);
-        if(resize_event)break;
-      }
-      updateGraph(&fps, os_window.app_data.iTimeDelta);
-      pxRatio = (float)fb.buffer_size.width / (float)winWidth;
+            float pxRatio;
 
-      int mx = os_window.app_data.iMouse[0];
-      int my = os_window.app_data.iResolution[1] - os_window.app_data.iMouse[1];
-    
-      nvgBeginFrame(vg, (float)winWidth, (float)winHeight, pxRatio);
-      renderDemo(vg, (float)mx, (float)my, (float)winWidth, (float)winHeight, (float)os_window.app_data.iTime, (int)os_window.app_data.blowup, &data);
-      renderGraph(vg, 5, 5, &fps);
+            int winWidth = os_window.app_data.iResolution[0];
+            int winHeight = os_window.app_data.iResolution[1];
+            if (resize_event) {
+                destroyFrameBuffers(device, &fb);
+                fb = createFrameBuffers(device, surface, queue, winWidth, winHeight, 0);
+                resize_event=false;
+            }else{
+                if (!os_window.is_minimized){
+                    prepareFrame(device->device, cmd_buffer, &fb);
+                    if(resize_event)break;
+                }
+                updateGraph(&fps, os_window.app_data.iTimeDelta);
+                pxRatio = (float)fb.buffer_size.width / (float)winWidth;
 
-      nvgEndFrame(vg);
-      
-      if (os_window.is_minimized)
-      { // I do not delete everything on minimize, only stop rendering
-          sleep_ms(10);
-      }
-      else {
-        submitFrame(device->device, queue, cmd_buffer, &fb);
-      }
-      update_params(&os_window.app_data, os_window.fps_lock);
+                int mx = os_window.app_data.iMouse[0];
+                int my = os_window.app_data.iResolution[1] - os_window.app_data.iMouse[1];
+
+                nvgBeginFrame(vg, (float)winWidth, (float)winHeight, pxRatio);
+                renderDemo(vg, (float)mx, (float)my, (float)winWidth, (float)winHeight, (float)os_window.app_data.iTime, (int)os_window.app_data.blowup, &data);
+                renderGraph(vg, 5, 5, &fps);
+
+                nvgEndFrame(vg);
+
+                if (os_window.is_minimized)
+                { // I do not delete everything on minimize, only stop rendering
+                    sleep_ms(10);
+                }
+                else {
+                    submitFrame(device->device, queue, cmd_buffer, &fb);
+                }
+                update_params(&os_window.app_data, os_window.fps_lock);
+            }
+
+            if(os_window.app_data.quit) PostQuitMessage(0);
+
+            break;
+        case WM_GETMINMAXINFO:
+            ((MINMAXINFO *)lParam)->ptMinTrackSize = os_window.minsize;
+            return 0;
+        case WM_SIZE:
+            if (wParam != SIZE_MINIMIZED) {
+                int tsize[2]={0};
+                tsize[0] = lParam & 0xffff;
+                tsize[1] = (lParam & 0xffff0000) >> 16;
+                os_window.is_minimized = false;
+                if((tsize[0]!=os_window.app_data.iResolution[0])||(tsize[1]!=os_window.app_data.iResolution[1])){
+                    os_window.app_data.iResolution[0]=tsize[0];
+                    os_window.app_data.iResolution[1]=tsize[1];
+                    if((os_window.app_data.iResolution[0]==0)||(os_window.app_data.iResolution[1]==0)){
+                        os_window.is_minimized = true;
+                    }else{
+                        resize_event=true;
+                    }
+                }
+            }
+            else{
+                if (wParam == SIZE_MINIMIZED){
+                    os_window.is_minimized = true;
+                }
+            }
+            break;
+        default:
+            break;
     }
-    
-    if(os_window.app_data.quit) PostQuitMessage(0);
-    
-    break;
-  case WM_GETMINMAXINFO:
-    ((MINMAXINFO *)lParam)->ptMinTrackSize = os_window.minsize;
-    return 0;
-  case WM_SIZE:
-    if (wParam != SIZE_MINIMIZED) {
-      int tsize[2]={0};
-      tsize[0] = lParam & 0xffff;
-      tsize[1] = (lParam & 0xffff0000) >> 16;
-      os_window.is_minimized = false;
-      if((tsize[0]!=os_window.app_data.iResolution[0])||(tsize[1]!=os_window.app_data.iResolution[1])){
-        os_window.app_data.iResolution[0]=tsize[0];
-        os_window.app_data.iResolution[1]=tsize[1];
-        if((os_window.app_data.iResolution[0]==0)||(os_window.app_data.iResolution[1]==0)){
-          os_window.is_minimized = true;
-        }else{
-          resize_event=true;
-        }
-      }
-    }
-    else{
-      if (wParam == SIZE_MINIMIZED){
-        os_window.is_minimized = true;
-      }
-    }
-    break;
-  default:
-    break;
-  }
-  return (DefWindowProc(hWnd, uMsg, wParam, lParam));
+    return (DefWindowProc(hWnd, uMsg, wParam, lParam));
 }
 
 static void app_create_window(struct app_os_window *os_window) {
-  WNDCLASSEX win_class;
+    WNDCLASSEX win_class;
 
-  win_class.cbSize = sizeof(WNDCLASSEX);
-  win_class.style = CS_HREDRAW | CS_VREDRAW;
-  win_class.lpfnWndProc = WndProc;
-  win_class.cbClsExtra = 0;
-  win_class.cbWndExtra = 0;
-  win_class.hInstance = os_window->connection;
-  win_class.hIcon = LoadIcon(NULL, IDI_APPLICATION);
-  win_class.hCursor = LoadCursor(NULL, IDC_ARROW);
-  win_class.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
-  win_class.lpszMenuName = NULL;
-  win_class.lpszClassName = os_window->name;
-  win_class.hIconSm = LoadIcon(NULL, IDI_WINLOGO);
-  if (!RegisterClassEx(&win_class)) {
-    printf("Unexpected error trying to start the application!\n");
-    fflush(stdout);
-    exit(1);
-  }
-  RECT wr = { 0, 0, os_window->app_data.iResolution[0], os_window->app_data.iResolution[1] };
-  AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
-  os_window->window = CreateWindowEx(0,
-    os_window->name,            // class name
-    os_window->name,            // app name
-    WS_OVERLAPPEDWINDOW |  // window style
-    WS_VISIBLE | WS_SYSMENU,
-    100, 100,            // x/y coords
-    wr.right - wr.left,  // width
-    wr.bottom - wr.top,  // height
-    NULL,                // handle to parent
-    NULL,                // handle to menu
-    os_window->connection,    // hInstance
-    NULL);               // no extra parameters
-  if (!os_window->window) {
-    printf("Cannot create a window in which to draw!\n");
-    fflush(stdout);
-    exit(1);
-  }
-  os_window->minsize.x = GetSystemMetrics(SM_CXMINTRACK);
-  os_window->minsize.y = GetSystemMetrics(SM_CYMINTRACK) + 1;
+    win_class.cbSize = sizeof(WNDCLASSEX);
+    win_class.style = CS_HREDRAW | CS_VREDRAW;
+    win_class.lpfnWndProc = WndProc;
+    win_class.cbClsExtra = 0;
+    win_class.cbWndExtra = 0;
+    win_class.hInstance = os_window->connection;
+    win_class.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    win_class.hCursor = LoadCursor(NULL, IDC_ARROW);
+    win_class.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
+    win_class.lpszMenuName = NULL;
+    win_class.lpszClassName = os_window->name;
+    win_class.hIconSm = LoadIcon(NULL, IDI_WINLOGO);
+    if (!RegisterClassEx(&win_class)) {
+        printf("Unexpected error trying to start the application!\n");
+        fflush(stdout);
+        exit(1);
+    }
+    RECT wr = { 0, 0, os_window->app_data.iResolution[0], os_window->app_data.iResolution[1] };
+    AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
+    os_window->window = CreateWindowEx(0,
+                                       os_window->name,            // class name
+                                       os_window->name,            // app name
+                                       WS_OVERLAPPEDWINDOW |  // window style
+                                       WS_VISIBLE | WS_SYSMENU,
+                                       100, 100,            // x/y coords
+                                       wr.right - wr.left,  // width
+                                       wr.bottom - wr.top,  // height
+                                       NULL,                // handle to parent
+                                       NULL,                // handle to menu
+                                       os_window->connection,    // hInstance
+                                       NULL);               // no extra parameters
+    if (!os_window->window) {
+        printf("Cannot create a window in which to draw!\n");
+        fflush(stdout);
+        exit(1);
+    }
+    os_window->minsize.x = GetSystemMetrics(SM_CXMINTRACK);
+    os_window->minsize.y = GetSystemMetrics(SM_CYMINTRACK) + 1;
 }
 
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
@@ -1061,38 +1059,38 @@ static void app_create_xcb_window(struct app_os_window *os_window) {
 
 int clock_gettime(int dummy, struct timespec *ct)
 {
-  static BOOL g_first_time = 1;
-  static LARGE_INTEGER g_counts_per_sec;
-  LARGE_INTEGER count;
-  if (g_first_time)
-  {
-    g_first_time = 0;
-    if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
+    static BOOL g_first_time = 1;
+    static LARGE_INTEGER g_counts_per_sec;
+    LARGE_INTEGER count;
+    if (g_first_time)
     {
-      g_counts_per_sec.QuadPart = 0;
+        g_first_time = 0;
+        if (0 == QueryPerformanceFrequency(&g_counts_per_sec))
+        {
+            g_counts_per_sec.QuadPart = 0;
+        }
     }
-  }
-  if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
-    (0 == QueryPerformanceCounter(&count)))
-  {
-    return -1;
-  }
-  ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
-  ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
+    if ((NULL == ct) || (g_counts_per_sec.QuadPart <= 0) ||
+        (0 == QueryPerformanceCounter(&count)))
+    {
+        return -1;
+    }
+    ct->tv_sec = count.QuadPart / g_counts_per_sec.QuadPart;
+    ct->tv_nsec = ((count.QuadPart % g_counts_per_sec.QuadPart) * BILLION) / g_counts_per_sec.QuadPart;
 
-  return 0;
+    return 0;
 }
 
 void get_local_time(struct my_time_struct *my_time){
-  SYSTEMTIME lt = {0};
+    SYSTEMTIME lt = {0};
     GetLocalTime(&lt);
-  my_time->msec=lt.wMilliseconds;
-  my_time->sec=lt.wSecond;
-  my_time->min=lt.wMinute;
-  my_time->hour=lt.wHour;
-  my_time->day=lt.wDay;
-  my_time->month=lt.wMonth;
-  my_time->year=lt.wYear;
+    my_time->msec=lt.wMilliseconds;
+    my_time->sec=lt.wSecond;
+    my_time->min=lt.wMinute;
+    my_time->hour=lt.wHour;
+    my_time->day=lt.wDay;
+    my_time->month=lt.wMonth;
+    my_time->year=lt.wYear;
 }
 
 
@@ -1126,29 +1124,29 @@ double get_time_ticks(){
 }
 
 float update_fps_delta(){
-  static double before_time=0;
-  if((int)before_time==0)before_time=get_time_ticks();
-  
+    static double before_time=0;
+    if((int)before_time==0)before_time=get_time_ticks();
+
     double now_time = get_time_ticks();
-    
+
     if ((long)before_time==(long)now_time) { //this happend on IMMEDIATE and MAILBOX
-    return 1.0/9999.0;
+        return 1.0/9999.0;
     }
     double tdelta=(now_time-before_time);
     if(tdelta<=0)tdelta=1;
     float delta=(float)tdelta/1000.0;
     if(delta>1){
-    delta=1;
-  }
-  if(delta<=0){
-    delta=1.0/9999.0;
-  }
+        delta=1;
+    }
+    if(delta<=0){
+        delta=1.0/9999.0;
+    }
     before_time=now_time;
     return delta;
 }
 
 // cross-platform sleep function
-void sleep_ms(int milliseconds) 
+void sleep_ms(int milliseconds)
 {
 #ifdef WIN32
     Sleep(milliseconds);
@@ -1161,24 +1159,24 @@ void sleep_ms(int milliseconds)
 }
 
 void FPS_LOCK(int fps){
-  static double before_time=0;
-  if(before_time==0)before_time=get_time_ticks();
-  double now_time=get_time_ticks();
-  if(before_time==now_time)return;
-  if(fps<=0)fps=1;
-  double wdelta=((double)(1.0/(double)fps)*(double)1000.0);
-  double tdelta=(now_time-before_time);
-  if(tdelta<=0)tdelta=1;
-  double rdelta=wdelta-tdelta;
-  if(rdelta<=0){
-    before_time=now_time;
+    static double before_time=0;
+    if(before_time==0)before_time=get_time_ticks();
+    double now_time=get_time_ticks();
+    if(before_time==now_time)return;
+    if(fps<=0)fps=1;
+    double wdelta=((double)(1.0/(double)fps)*(double)1000.0);
+    double tdelta=(now_time-before_time);
+    if(tdelta<=0)tdelta=1;
+    double rdelta=wdelta-tdelta;
+    if(rdelta<=0){
+        before_time=now_time;
+        return;
+    }
+    sleep_ms((int)rdelta);
+    before_time=get_time_ticks();
+
     return;
-  }
-  sleep_ms((int)rdelta);
-  before_time=get_time_ticks();
-  
-  return;
-  
+
 }
 
 

--- a/example/example_vulkan_min_no_glfw.c
+++ b/example/example_vulkan_min_no_glfw.c
@@ -165,7 +165,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
 
   // Get the index of the next available swapchain image:
   res = vkAcquireNextImageKHR(device, fb->swap_chain, UINT64_MAX,
-                              fb->present_complete_semaphore[fb->current_frame],
+                              fb->present_complete_semaphore[fb->current_buffer],
                               VK_NULL_HANDLE,
                               &fb->current_buffer);
   if (res == VK_ERROR_OUT_OF_DATE_KHR)
@@ -177,7 +177,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   assert(res == VK_SUCCESS);
 
   const VkCommandBufferBeginInfo cmd_buf_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-  res = vkBeginCommandBuffer(cmd_buffer[fb->current_frame], &cmd_buf_info);
+  res = vkBeginCommandBuffer(cmd_buffer[fb->current_buffer], &cmd_buf_info);
   assert(res == VK_SUCCESS);
 
   VkClearValue clear_values[2];
@@ -200,7 +200,7 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   rp_begin.clearValueCount = 2;
   rp_begin.pClearValues = clear_values;
 
-  vkCmdBeginRenderPass(cmd_buffer[fb->current_frame], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+  vkCmdBeginRenderPass(cmd_buffer[fb->current_buffer], &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
 
   VkViewport viewport;
   viewport.width = (float) fb->buffer_size.width;
@@ -209,16 +209,16 @@ void prepareFrame(VkDevice device, VkCommandBuffer *cmd_buffer, FrameBuffers *fb
   viewport.maxDepth = (float) 1.0f;
   viewport.x = (float) rp_begin.renderArea.offset.x;
   viewport.y = (float) rp_begin.renderArea.offset.y;
-  vkCmdSetViewport(cmd_buffer[fb->current_frame], 0, 1, &viewport);
+  vkCmdSetViewport(cmd_buffer[fb->current_buffer], 0, 1, &viewport);
 
   VkRect2D scissor = rp_begin.renderArea;
-  vkCmdSetScissor(cmd_buffer[fb->current_frame], 0, 1, &scissor);
+  vkCmdSetScissor(cmd_buffer[fb->current_buffer], 0, 1, &scissor);
 }
 
 void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, FrameBuffers *fb) {
   VkResult res;
 
-  vkCmdEndRenderPass(cmd_buffer[fb->current_frame]);
+  vkCmdEndRenderPass(cmd_buffer[fb->current_buffer]);
 
   VkImageMemoryBarrier image_barrier = {
       .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
@@ -237,7 +237,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
           .layerCount = 1,
       },
   };
-  vkCmdPipelineBarrier(cmd_buffer[fb->current_frame],
+  vkCmdPipelineBarrier(cmd_buffer[fb->current_buffer],
             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
             0,
@@ -245,21 +245,22 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
             0, NULL,
             1, &image_barrier);
 
-  vkEndCommandBuffer(cmd_buffer[fb->current_frame]);
+  vkEndCommandBuffer(cmd_buffer[fb->current_buffer]);
 
   VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
   VkSubmitInfo submit_info = {VK_STRUCTURE_TYPE_SUBMIT_INFO};
   submit_info.pNext = NULL;
   submit_info.waitSemaphoreCount = 1;
-  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_frame];
+  submit_info.pWaitSemaphores = &fb->present_complete_semaphore[fb->current_buffer];
   submit_info.pWaitDstStageMask = &pipe_stage_flags;
   submit_info.commandBufferCount = 1;
-  submit_info.pCommandBuffers = &cmd_buffer[fb->current_frame];
+  submit_info.pCommandBuffers = &cmd_buffer[fb->current_buffer];
   submit_info.signalSemaphoreCount = 1;
-  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_frame];
+  submit_info.pSignalSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
 
   /* Queue the command buffer for execution */
+  vkResetFences(device, 1, &fb->flight_fence[fb->current_buffer]);
   res = vkQueueSubmit(queue, 1, &submit_info, 0);
   assert(res == VK_SUCCESS);
 
@@ -271,7 +272,7 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   present.pSwapchains = &fb->swap_chain;
   present.pImageIndices = &fb->current_buffer;
   present.waitSemaphoreCount = 1;
-  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_frame];
+  present.pWaitSemaphores = &fb->render_complete_semaphore[fb->current_buffer];
 
   res = vkQueuePresentKHR(queue, &present);
   if (res == VK_ERROR_OUT_OF_DATE_KHR)
@@ -283,10 +284,10 @@ void submitFrame(VkDevice device, VkQueue queue, VkCommandBuffer *cmd_buffer, Fr
   }
   assert(res == VK_SUCCESS);
 
-  res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_frame], true, UINT64_MAX);
+  res = vkWaitForFences(device, 1, &fb->flight_fence[fb->current_buffer], true, UINT64_MAX);
   assert(res == VK_SUCCESS || res == VK_TIMEOUT);
 
-  fb->current_frame = (fb->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+  //fb->current_frame = (fb->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
 }
 
 void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidth, int winHeight, VkQueue *queue, NVGcontext **vg,
@@ -296,14 +297,14 @@ void init_nanovg_vulkan(VkPhysicalDevice gpu, VkSurfaceKHR *surface, int winWidt
   vkGetDeviceQueue((*device)->device, (*device)->graphicsQueueFamilyIndex, 0, queue);
   *fb = createFrameBuffers((*device), *surface, *queue, winWidth, winHeight, 0);
 
-  (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, MAX_FRAMES_IN_FLIGHT);
+  (*cmd_buffer) = createCmdBuffer((*device)->device, (*device)->commandPool, fb->swapchain_image_count);
   VKNVGCreateInfo create_info = {0};
   create_info.device = (*device)->device;
   create_info.gpu = (*device)->gpu;
   create_info.renderpass = fb->render_pass;
   create_info.cmdBuffer = (*cmd_buffer);
-  create_info.maxFramesInFlight = MAX_FRAMES_IN_FLIGHT;
-  create_info.currentFrame = &fb->current_frame;
+  create_info.swapchainImageCount = fb->swapchain_image_count;
+  create_info.currentBuffer = &fb->current_buffer;
 
   int flags = 0;
 #ifndef NDEBUG

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -718,7 +718,9 @@ FrameBuffers createFrameBuffers(const VulkanDevice *device, VkSurfaceKHR surface
 
   return buffer;
 }
-void destroyFrameBuffers(const VulkanDevice *device, FrameBuffers *buffer) {
+void destroyFrameBuffers(const VulkanDevice *device, FrameBuffers *buffer, VkQueue queue) {
+  VkResult res = vkQueueWaitIdle(queue);
+  assert(res == VK_SUCCESS);
 
   for (uint32_t i = 0; i < buffer->swapchain_image_count; ++i) {
     if (buffer->present_complete_semaphore[i] != VK_NULL_HANDLE) {

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -98,6 +98,8 @@ typedef struct FrameBuffers {
   VkFramebuffer *framebuffers;
 
   uint32_t current_buffer;
+  uint32_t max_frames_in_flight;
+  uint32_t current_frame;
 
   VkExtent2D buffer_size;
 
@@ -237,15 +239,15 @@ VkCommandPool createCmdPool(VulkanDevice *device) {
   assert(res == VK_SUCCESS);
   return cmd_pool;
 }
-VkCommandBuffer* createCmdBuffer(VkDevice device, VkCommandPool cmd_pool, uint32_t swapchain_image_count) {
+VkCommandBuffer* createCmdBuffer(VkDevice device, VkCommandPool cmd_pool, uint32_t command_buffer_count) {
 
     VkResult res;
     VkCommandBufferAllocateInfo cmd = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
     cmd.commandPool = cmd_pool;
     cmd.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    cmd.commandBufferCount = swapchain_image_count;
+    cmd.commandBufferCount = command_buffer_count;
 
-    VkCommandBuffer *cmd_buffer = calloc(swapchain_image_count, sizeof (VkCommandBuffer));
+    VkCommandBuffer *cmd_buffer = calloc(command_buffer_count, sizeof (VkCommandBuffer));
     res = vkAllocateCommandBuffers(device, &cmd, cmd_buffer);
     assert(res == VK_SUCCESS);
     return cmd_buffer;

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -1,10 +1,6 @@
 
 #pragma once
 
-#ifndef MAX_FRAMES_IN_FLIGHT
-#   define MAX_FRAMES_IN_FLIGHT 3
-#endif
-
 typedef struct VulkanDevice {
   VkPhysicalDevice gpu;
   VkPhysicalDeviceProperties gpuProperties;
@@ -102,8 +98,7 @@ typedef struct FrameBuffers {
   VkFramebuffer *framebuffers;
 
   uint32_t current_buffer;
-  uint32_t max_frames_in_flight;
-  uint32_t current_frame;
+  //uint32_t current_frame;
 
   VkExtent2D buffer_size;
 
@@ -683,13 +678,13 @@ FrameBuffers createFrameBuffers(const VulkanDevice *device, VkSurfaceKHR surface
   buffer.buffer_size = buffer_size;
   buffer.render_pass = render_pass;
   buffer.depth = depth;
-  buffer.present_complete_semaphore = (VkSemaphore *)calloc(MAX_FRAMES_IN_FLIGHT, sizeof(VkSemaphore));
-  buffer.render_complete_semaphore = (VkSemaphore *)calloc(MAX_FRAMES_IN_FLIGHT, sizeof(VkSemaphore));
-  buffer.flight_fence = (VkFence *)calloc(MAX_FRAMES_IN_FLIGHT, sizeof(VkFence));
+  buffer.present_complete_semaphore = (VkSemaphore *)calloc(swapchain_image_count, sizeof(VkSemaphore));
+  buffer.render_complete_semaphore = (VkSemaphore *)calloc(swapchain_image_count, sizeof(VkSemaphore));
+  buffer.flight_fence = (VkFence *)calloc(swapchain_image_count, sizeof(VkFence));
 
   VkSemaphoreCreateInfo presentCompleteSemaphoreCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
   VkFenceCreateInfo fenceCreateInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-  for (i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
+  for (i = 0; i < swapchain_image_count; i++) {
     res = vkCreateSemaphore(device->device, &presentCompleteSemaphoreCreateInfo, NULL, &buffer.present_complete_semaphore[i]);
     assert(res == VK_SUCCESS);
 

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -98,7 +98,7 @@ typedef struct FrameBuffers {
   VkFramebuffer *framebuffers;
 
   uint32_t current_buffer;
-  //uint32_t current_frame;
+  uint32_t current_frame;
 
   VkExtent2D buffer_size;
 

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -17,7 +17,9 @@ typedef struct VKNVGCreateInfo {
   VkPhysicalDevice gpu;
   VkDevice device;
   VkRenderPass renderpass;
-  VkCommandBuffer cmdBuffer;
+  VkCommandBuffer *cmdBuffer;
+  uint32_t swapChainImageCount;
+  uint32_t *currentBuffer;
 
   const VkAllocationCallbacks *allocator; //Allocator for vulkan. can be null
 } VKNVGCreateInfo;
@@ -1056,7 +1058,8 @@ static void vknvg_fill(VKNVGcontext *vk, VKNVGcall *call) {
   int i, npaths = call->pathCount;
 
   VkDevice device = vk->createInfo.device;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer;
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
 
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1126,7 +1129,8 @@ static void vknvg_convexFill(VKNVGcontext *vk, VKNVGcall *call) {
   int npaths = call->pathCount;
 
   VkDevice device = vk->createInfo.device;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer;
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
   
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1172,9 +1176,10 @@ static void vknvg_convexFill(VKNVGcontext *vk, VKNVGcall *call) {
 
 static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call) {
   VkDevice device = vk->createInfo.device;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer;
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
 
-  VKNVGpath *paths = &vk->paths[call->pathOffset];
+    VKNVGpath *paths = &vk->paths[call->pathOffset];
   int npaths = call->pathCount;
 
   if (vk->flags & NVG_STENCIL_STROKES) {
@@ -1270,7 +1275,8 @@ static void vknvg_triangles(VKNVGcontext *vk, VKNVGcall *call) {
     return;
   }
   VkDevice device = vk->createInfo.device;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer;
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
 
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1460,8 +1466,9 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
     vknvg_UpdateTexture(device, tex, 0, 0, w, h, generated_texture);
     free(generated_texture);
   }
-  
-  vknvg_InitTexture(vk->createInfo.cmdBuffer, vk->queue, tex);
+
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  vknvg_InitTexture(vk->createInfo.cmdBuffer[currentBuffer], vk->queue, tex);
 
   return vknvg_textureId(vk, tex);
 }
@@ -1507,8 +1514,8 @@ static void vknvg_renderCancel(void *uptr) {
 static void vknvg_renderFlush(void *uptr) {
   VKNVGcontext *vk = (VKNVGcontext *)uptr;
   VkDevice device = vk->createInfo.device;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer;
-  VkRenderPass renderpass = vk->createInfo.renderpass;
+  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
   VkPhysicalDeviceMemoryProperties memoryProperties = vk->memoryProperties;
   const VkAllocationCallbacks *allocator = vk->createInfo.allocator;
 

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -18,8 +18,8 @@ typedef struct VKNVGCreateInfo {
   VkDevice device;
   VkRenderPass renderpass;
   VkCommandBuffer *cmdBuffer;
-  uint32_t swapChainImageCount;
-  uint32_t *currentBuffer;
+  uint32_t maxFramesInFlight;
+  uint32_t *currentFrame;
 
   const VkAllocationCallbacks *allocator; //Allocator for vulkan. can be null
 } VKNVGCreateInfo;
@@ -1058,8 +1058,8 @@ static void vknvg_fill(VKNVGcontext *vk, VKNVGcall *call) {
   int i, npaths = call->pathCount;
 
   VkDevice device = vk->createInfo.device;
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentFrame];
 
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1129,8 +1129,8 @@ static void vknvg_convexFill(VKNVGcontext *vk, VKNVGcall *call) {
   int npaths = call->pathCount;
 
   VkDevice device = vk->createInfo.device;
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentFrame];
   
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1176,8 +1176,8 @@ static void vknvg_convexFill(VKNVGcontext *vk, VKNVGcall *call) {
 
 static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call) {
   VkDevice device = vk->createInfo.device;
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentFrame];
 
     VKNVGpath *paths = &vk->paths[call->pathOffset];
   int npaths = call->pathCount;
@@ -1275,8 +1275,8 @@ static void vknvg_triangles(VKNVGcontext *vk, VKNVGcall *call) {
     return;
   }
   VkDevice device = vk->createInfo.device;
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
+  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentFrame];
 
 #ifdef __cplusplus
   VKNVGCreatePipelineKey pipelinekey = {};
@@ -1467,8 +1467,8 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
     free(generated_texture);
   }
 
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  vknvg_InitTexture(vk->createInfo.cmdBuffer[currentBuffer], vk->queue, tex);
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
+  vknvg_InitTexture(vk->createInfo.cmdBuffer[currentFrame], vk->queue, tex);
 
   return vknvg_textureId(vk, tex);
 }
@@ -1514,8 +1514,7 @@ static void vknvg_renderCancel(void *uptr) {
 static void vknvg_renderFlush(void *uptr) {
   VKNVGcontext *vk = (VKNVGcontext *)uptr;
   VkDevice device = vk->createInfo.device;
-  uint32_t currentBuffer = *vk->createInfo.currentBuffer;
-  VkCommandBuffer cmdBuffer = vk->createInfo.cmdBuffer[currentBuffer];
+  uint32_t currentFrame = *vk->createInfo.currentFrame;
   VkPhysicalDeviceMemoryProperties memoryProperties = vk->memoryProperties;
   const VkAllocationCallbacks *allocator = vk->createInfo.allocator;
 

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -438,7 +438,7 @@ static int vknvg_convertPaint(VKNVGcontext *vk, VKNVGfragUniforms *frag, NVGpain
   return 1;
 }
 
-static VKNVGBuffer vknvg_createBuffer(VkDevice device, VkPhysicalDeviceMemoryProperties memoryProperties, const VkAllocationCallbacks *allocator, VkBufferUsageFlags usage, VkMemoryPropertyFlagBits memory_type, void *data, uint32_t size) {
+static VKNVGBuffer vknvg_createBuffer(VkDevice device, VkPhysicalDeviceMemoryProperties memoryProperties, const VkAllocationCallbacks *allocator, VkBufferUsageFlags usage, VkFlags memory_type, void *data, uint32_t size) {
 
   const VkBufferCreateInfo buf_createInfo = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, nullptr, 0, size, usage};
 
@@ -475,7 +475,7 @@ static void vknvg_destroyBuffer(VkDevice device, const VkAllocationCallbacks *al
   vkFreeMemory(device, buffer->mem, allocator);
 }
 
-static void vknvg_UpdateBuffer(VkDevice device, const VkAllocationCallbacks *allocator, VKNVGBuffer *buffer, VkPhysicalDeviceMemoryProperties memoryProperties, VkBufferUsageFlags usage, VkMemoryPropertyFlagBits memory_type, void *data, uint32_t size) {
+static void vknvg_UpdateBuffer(VkDevice device, const VkAllocationCallbacks *allocator, VKNVGBuffer *buffer, VkPhysicalDeviceMemoryProperties memoryProperties, VkBufferUsageFlags usage, VkFlags memory_type, void *data, uint32_t size) {
   if (buffer->size < size) {
     vknvg_destroyBuffer(device, allocator, buffer);
     *buffer = vknvg_createBuffer(device, memoryProperties, allocator, usage, memory_type, data, size);
@@ -1501,9 +1501,10 @@ static void vknvg_renderFlush(void *uptr) {
 
   int i;
   if (vk->ncalls > 0) {
-    vknvg_UpdateBuffer(device, allocator, &vk->vertexBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, vk->verts, vk->nverts * sizeof(vk->verts[0]));
-    vknvg_UpdateBuffer(device, allocator, &vk->fragUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, vk->uniforms, vk->nuniforms * vk->fragSize);
-    vknvg_UpdateBuffer(device, allocator, &vk->vertUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, vk->view, sizeof(vk->view));
+    VkFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    vknvg_UpdateBuffer(device, allocator, &vk->vertexBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, flags, vk->verts, vk->nverts * sizeof(vk->verts[0]));
+    vknvg_UpdateBuffer(device, allocator, &vk->fragUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,flags, vk->uniforms, vk->nuniforms * vk->fragSize);
+    vknvg_UpdateBuffer(device, allocator, &vk->vertUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, flags, vk->view, sizeof(vk->view));
     vk->currentPipeline = nullptr;
 
     if (vk->ncalls > vk->cdescPool) {

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1089,8 +1089,8 @@ static void vknvg_fill(VKNVGcontext *vk, VKNVGcall *call, uint32_t call_index) {
     vkCmdDraw(cmdBuffer, paths[i].fillCount, 1, 0, 0);
   }
 
-  vknvg_setUniforms(vk, vk->uniformDescriptorSet1[call_index], call->uniformOffset + vk->fragSize, call->image);
-  vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet1[call_index], 0, nullptr);
+  vknvg_setUniforms(vk, vk->uniformDescriptorSet2[call_index], call->uniformOffset + vk->fragSize, call->image);
+  vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet2[call_index], 0, nullptr);
 
   if (vk->flags & NVG_ANTIALIAS) {
 

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1194,8 +1194,9 @@ static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call, uint32_t call_index)
     vknvg_bindPipeline(vk, cmdBuffer, &pipelinekey);
     vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet2[call_index], 0, nullptr);
 
+    VkDeviceSize offsets[] = {0};
     for (int i = 0; i < npaths; ++i) {
-      const VkDeviceSize offsets[1] = {paths[i].strokeOffset * sizeof(NVGvertex)};
+      offsets[0] = paths[i].strokeOffset * sizeof(NVGvertex);
       vkCmdBindVertexBuffers(cmdBuffer, 0, 1, &vk->vertexBuffer[currentFrame].buffer, offsets);
       vkCmdDraw(cmdBuffer, paths[i].strokeCount, 1, 0, 0);
     }
@@ -1206,7 +1207,7 @@ static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call, uint32_t call_index)
      vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet1[call_index], 0, nullptr);
 
      for (int i = 0; i < npaths; ++i) {
-       const VkDeviceSize offsets[1] = {paths[i].strokeOffset * sizeof(NVGvertex)};
+       offsets[0] = paths[i].strokeOffset * sizeof(NVGvertex);
        vkCmdBindVertexBuffers(cmdBuffer, 0, 1, &vk->vertexBuffer[currentFrame].buffer, offsets);
        vkCmdDraw(cmdBuffer, paths[i].strokeCount, 1, 0, 0);
      }
@@ -1217,7 +1218,7 @@ static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call, uint32_t call_index)
      vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet1[call_index], 0, nullptr);
 
      for (int i = 0; i < npaths; ++i) {
-       const VkDeviceSize offsets[1] = {paths[i].strokeOffset * sizeof(NVGvertex)};
+       offsets[0] = paths[i].strokeOffset * sizeof(NVGvertex);
        vkCmdBindVertexBuffers(cmdBuffer, 0, 1, &vk->vertexBuffer[currentFrame].buffer, offsets);
        vkCmdDraw(cmdBuffer, paths[i].strokeCount, 1, 0, 0);
      }
@@ -1239,8 +1240,9 @@ static void vknvg_stroke(VKNVGcontext *vk, VKNVGcall *call, uint32_t call_index)
     vkCmdBindDescriptorSets(cmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, vk->pipelineLayout, 0, 1, &vk->uniformDescriptorSet1[call_index], 0, nullptr);
     // Draw Strokes
 
+    VkDeviceSize offsets[] = {0};
     for (int i = 0; i < npaths; ++i) {
-      const VkDeviceSize offsets[1] = {paths[i].strokeOffset * sizeof(NVGvertex)};
+      offsets[0] = paths[i].strokeOffset * sizeof(NVGvertex);
       vkCmdBindVertexBuffers(cmdBuffer, 0, 1, &vk->vertexBuffer[currentFrame].buffer, offsets);
       vkCmdDraw(cmdBuffer, paths[i].strokeCount, 1, 0, 0);
     }

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1784,6 +1784,9 @@ static void vknvg_renderDelete(void *uptr) {
   free(vk->fragUniformBuffer);
   free(vk->vertUniformBuffer);
 
+  free(vk->uniformDescriptorSet1);
+  free(vk->uniformDescriptorSet2);
+
   free(vk->textures);
   free(vk->pipelines);
   free(vk->calls);


### PR DESCRIPTION
Hi Everyone.

This PR is a followup to a comment I left a few months ago, visible here https://github.com/memononen/nanovg/issues/614#issuecomment-1426870962

I made some optimizations that have doubled the frame-rate of the `example_vulkan` demo on my machine. These changes do not break compatibility with the older implementations either, specifically with `example_vulkan_min_no_glfw`.

The changes I made are listed below:

- Support for multiple command buffers, specifically one per swap-chain image / buffer
- Caching of descriptor sets, removing the need to create new ones per draw func or to call `vkResetDescriptorPool` per frame.
- Under `example_vulkan`, using `vkWaitForFences` to control rendering as opposed to `vkQueueWaitIdle` (seems to be the biggest perf booster). This change also has implied "multiple frames in flight" as dictated by the swap-chain image count.
- Using persisted mapped buffers via `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT` instead of `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT `, allows to skip calls to `vkMap/UnmapMemory` per frame

The best way to observe the differences in performance is to run `example_vulkan` and `example_vulkan_min_no_glfw` separately. On my system ( RX 6800, Ryzen R7 7700 ) the `example_vulkan` demo has an average frame time of 0.80 ms (1250 fps) as opposed to the `example_vulkan_min_no_glfw` demo with 1.98 ms (505 fps). For reference `example-gl3` runs at 0.55 ms (1818 fps), but this is a big improvement as `example_vulkan` is now just 31% slower as opposed to 72% slower for `example_vulkan_min_no_glfw`.

The main difference in terms of setup is:

- Treating `cmd_buffer` as an array
- Setting `swapchainImageCount` and `* currentBuffer` within the `VKNVGCreateInfo` init. 

Open for comments and feedback, particular around tests on Nvidia, Intel and Apple Silicon hardware.

![Screenshot 2023-06-12 115445](https://github.com/danilw/nanovg_vulkan/assets/16505156/e2f946a3-c897-40ef-9901-8a1eb202d9b0)

![Screenshot 2023-06-12 115528](https://github.com/danilw/nanovg_vulkan/assets/16505156/164b8d91-875e-47a8-82e4-ea2819b85699)
